### PR TITLE
PR Fix segfault error on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: "3.6"
 
 install:
   - sudo apt-get update
-  - pip install pyqt5
+  - sudo apt-get install python3-pyqt5
   - sudo apt-get install cython3
   - sudo apt-get install libhdf5-dev
   - pip install h5py
@@ -19,11 +19,6 @@ install:
   - pip install pytest-ordering
   - pip install coveralls
   - pip install matplotlib
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
 
 script:
   python runtests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: "3.6"
 
 install:
   - sudo apt-get update
-  - sudo apt-get install python3-pyqt5
+  - pip install pyqt5
   - sudo apt-get install cython3
   - sudo apt-get install libhdf5-dev
   - pip install h5py

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -200,6 +200,7 @@ class DwnldWeatherWidget(QWidget):
         btn_selectRaw.setIcon(IconDB().openFile)
         btn_selectRaw.setToolTip('Select and format raw weather data files')
         btn_selectRaw.setIconSize(IconDB().iconSize2)
+        self.btn_selectRaw = btn_selectRaw
 
         btn_saveMerge = QPushButton('Save')
         btn_saveMerge.setToolTip('Save formated weather data in a csv file')

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -595,7 +595,7 @@ class DwnldWeatherWidget(QWidget):
         self.mergeHistoryLog.append(html)
         self.mergeHistoryIndx = len(self.mergeHistoryLog) - 1
         self.mergeHistoryFnames.append(filepaths)
-        # self.display_mergeHistory()
+        self.display_mergeHistory()
 
         if self.saveAuto_checkbox.isChecked():
             dirname = os.path.join(self.workdir, 'Meteo', 'Input')

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -66,7 +66,6 @@ class DwnldWeatherWidget(QWidget):
 
     ConsoleSignal = QSignal(str)
     sig_download_process_ended = QSignal()
-    sig_merge_summary_displayed = QSignal()
 
     def __init__(self, parent=None):
         super(DwnldWeatherWidget, self).__init__(parent)
@@ -545,24 +544,22 @@ class DwnldWeatherWidget(QWidget):
             self.mergeHistoryIndx += 1
 
         self.mergeDisplay.setHtml(self.mergeHistoryLog[self.mergeHistoryIndx])
-        if len(self.mergeHistoryLog) > 1:
-            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
-                self.btn_goLast.setEnabled(False)
-                self.btn_goNext.setEnabled(False)
-                self.btn_goFirst.setEnabled(True)
-                self.btn_goPrevious.setEnabled(True)
-            elif self.mergeHistoryIndx == 0:
-                self.btn_goLast.setEnabled(True)
-                self.btn_goNext.setEnabled(True)
-                self.btn_goFirst.setEnabled(False)
-                self.btn_goPrevious.setEnabled(False)
-            else:
-                self.btn_goLast.setEnabled(True)
-                self.btn_goNext.setEnabled(True)
-                self.btn_goFirst.setEnabled(True)
-                self.btn_goPrevious.setEnabled(True)
-
-        self.sig_merge_summary_displayed.emit()
+#        if len(self.mergeHistoryLog) > 1:
+#            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
+#                self.btn_goLast.setEnabled(False)
+#                self.btn_goNext.setEnabled(False)
+#                self.btn_goFirst.setEnabled(True)
+#                self.btn_goPrevious.setEnabled(True)
+#            elif self.mergeHistoryIndx == 0:
+#                self.btn_goLast.setEnabled(True)
+#                self.btn_goNext.setEnabled(True)
+#                self.btn_goFirst.setEnabled(False)
+#                self.btn_goPrevious.setEnabled(False)
+#            else:
+#                self.btn_goLast.setEnabled(True)
+#                self.btn_goNext.setEnabled(True)
+#                self.btn_goFirst.setEnabled(True)
+#                self.btn_goPrevious.setEnabled(True)
 
     def btn_selectRaw_isClicked(self):
         """

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -544,22 +544,22 @@ class DwnldWeatherWidget(QWidget):
             self.mergeHistoryIndx += 1
 
         self.mergeDisplay.setHtml(self.mergeHistoryLog[self.mergeHistoryIndx])
-        if len(self.mergeHistoryLog) > 1:
-            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
-                self.btn_goLast.setEnabled(False)
-                self.btn_goNext.setEnabled(False)
-                self.btn_goFirst.setEnabled(True)
-                self.btn_goPrevious.setEnabled(True)
-            elif self.mergeHistoryIndx == 0:
-                self.btn_goLast.setEnabled(True)
-                self.btn_goNext.setEnabled(True)
-                self.btn_goFirst.setEnabled(False)
-                self.btn_goPrevious.setEnabled(False)
-            else:
-                self.btn_goLast.setEnabled(True)
-                self.btn_goNext.setEnabled(True)
-                self.btn_goFirst.setEnabled(True)
-                self.btn_goPrevious.setEnabled(True)
+#        if len(self.mergeHistoryLog) > 1:
+#            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
+#                self.btn_goLast.setEnabled(False)
+#                self.btn_goNext.setEnabled(False)
+#                self.btn_goFirst.setEnabled(True)
+#                self.btn_goPrevious.setEnabled(True)
+#            elif self.mergeHistoryIndx == 0:
+#                self.btn_goLast.setEnabled(True)
+#                self.btn_goNext.setEnabled(True)
+#                self.btn_goFirst.setEnabled(False)
+#                self.btn_goPrevious.setEnabled(False)
+#            else:
+#                self.btn_goLast.setEnabled(True)
+#                self.btn_goNext.setEnabled(True)
+#                self.btn_goFirst.setEnabled(True)
+#                self.btn_goPrevious.setEnabled(True)
 
     def btn_selectRaw_isClicked(self):
         """

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -543,8 +543,7 @@ class DwnldWeatherWidget(QWidget):
         elif button == self.btn_goNext:
             self.mergeHistoryIndx += 1
 
-#        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
-#        self.mergeDisplay.setText("Segmentation Fault my ass")
+        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
         if len(self.mergeHistoryLog) > 1:
             if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
                 self.btn_goLast.setEnabled(False)

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -543,24 +543,23 @@ class DwnldWeatherWidget(QWidget):
         elif button == self.btn_goNext:
             self.mergeHistoryIndx += 1
 
-        self.mergeDisplay.setText("test")
-#        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
-#        if len(self.mergeHistoryLog) > 1:
-#            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
-#                self.btn_goLast.setEnabled(False)
-#                self.btn_goNext.setEnabled(False)
-#                self.btn_goFirst.setEnabled(True)
-#                self.btn_goPrevious.setEnabled(True)
-#            elif self.mergeHistoryIndx == 0:
-#                self.btn_goLast.setEnabled(True)
-#                self.btn_goNext.setEnabled(True)
-#                self.btn_goFirst.setEnabled(False)
-#                self.btn_goPrevious.setEnabled(False)
-#            else:
-#                self.btn_goLast.setEnabled(True)
-#                self.btn_goNext.setEnabled(True)
-#                self.btn_goFirst.setEnabled(True)
-#                self.btn_goPrevious.setEnabled(True)
+        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
+        if len(self.mergeHistoryLog) > 1:
+            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
+                self.btn_goLast.setEnabled(False)
+                self.btn_goNext.setEnabled(False)
+                self.btn_goFirst.setEnabled(True)
+                self.btn_goPrevious.setEnabled(True)
+            elif self.mergeHistoryIndx == 0:
+                self.btn_goLast.setEnabled(True)
+                self.btn_goNext.setEnabled(True)
+                self.btn_goFirst.setEnabled(False)
+                self.btn_goPrevious.setEnabled(False)
+            else:
+                self.btn_goLast.setEnabled(True)
+                self.btn_goNext.setEnabled(True)
+                self.btn_goFirst.setEnabled(True)
+                self.btn_goPrevious.setEnabled(True)
 
     def btn_selectRaw_isClicked(self):
         """

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -66,6 +66,7 @@ class DwnldWeatherWidget(QWidget):
 
     ConsoleSignal = QSignal(str)
     sig_download_process_ended = QSignal()
+    sig_merge_summary_displayed = QSignal()
 
     def __init__(self, parent=None):
         super(DwnldWeatherWidget, self).__init__(parent)
@@ -544,22 +545,24 @@ class DwnldWeatherWidget(QWidget):
             self.mergeHistoryIndx += 1
 
         self.mergeDisplay.setHtml(self.mergeHistoryLog[self.mergeHistoryIndx])
-#        if len(self.mergeHistoryLog) > 1:
-#            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
-#                self.btn_goLast.setEnabled(False)
-#                self.btn_goNext.setEnabled(False)
-#                self.btn_goFirst.setEnabled(True)
-#                self.btn_goPrevious.setEnabled(True)
-#            elif self.mergeHistoryIndx == 0:
-#                self.btn_goLast.setEnabled(True)
-#                self.btn_goNext.setEnabled(True)
-#                self.btn_goFirst.setEnabled(False)
-#                self.btn_goPrevious.setEnabled(False)
-#            else:
-#                self.btn_goLast.setEnabled(True)
-#                self.btn_goNext.setEnabled(True)
-#                self.btn_goFirst.setEnabled(True)
-#                self.btn_goPrevious.setEnabled(True)
+        if len(self.mergeHistoryLog) > 1:
+            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
+                self.btn_goLast.setEnabled(False)
+                self.btn_goNext.setEnabled(False)
+                self.btn_goFirst.setEnabled(True)
+                self.btn_goPrevious.setEnabled(True)
+            elif self.mergeHistoryIndx == 0:
+                self.btn_goLast.setEnabled(True)
+                self.btn_goNext.setEnabled(True)
+                self.btn_goFirst.setEnabled(False)
+                self.btn_goPrevious.setEnabled(False)
+            else:
+                self.btn_goLast.setEnabled(True)
+                self.btn_goNext.setEnabled(True)
+                self.btn_goFirst.setEnabled(True)
+                self.btn_goPrevious.setEnabled(True)
+
+        self.sig_merge_summary_displayed.emit()
 
     def btn_selectRaw_isClicked(self):
         """

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -543,23 +543,24 @@ class DwnldWeatherWidget(QWidget):
         elif button == self.btn_goNext:
             self.mergeHistoryIndx += 1
 
-        self.mergeDisplay.setHtml(self.mergeHistoryLog[self.mergeHistoryIndx])
-#        if len(self.mergeHistoryLog) > 1:
-#            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
-#                self.btn_goLast.setEnabled(False)
-#                self.btn_goNext.setEnabled(False)
-#                self.btn_goFirst.setEnabled(True)
-#                self.btn_goPrevious.setEnabled(True)
-#            elif self.mergeHistoryIndx == 0:
-#                self.btn_goLast.setEnabled(True)
-#                self.btn_goNext.setEnabled(True)
-#                self.btn_goFirst.setEnabled(False)
-#                self.btn_goPrevious.setEnabled(False)
-#            else:
-#                self.btn_goLast.setEnabled(True)
-#                self.btn_goNext.setEnabled(True)
-#                self.btn_goFirst.setEnabled(True)
-#                self.btn_goPrevious.setEnabled(True)
+        # self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
+        self.mergeDisplay.setText("Segmentation Fault my ass)
+        if len(self.mergeHistoryLog) > 1:
+            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
+                self.btn_goLast.setEnabled(False)
+                self.btn_goNext.setEnabled(False)
+                self.btn_goFirst.setEnabled(True)
+                self.btn_goPrevious.setEnabled(True)
+            elif self.mergeHistoryIndx == 0:
+                self.btn_goLast.setEnabled(True)
+                self.btn_goNext.setEnabled(True)
+                self.btn_goFirst.setEnabled(False)
+                self.btn_goPrevious.setEnabled(False)
+            else:
+                self.btn_goLast.setEnabled(True)
+                self.btn_goNext.setEnabled(True)
+                self.btn_goFirst.setEnabled(True)
+                self.btn_goPrevious.setEnabled(True)
 
     def btn_selectRaw_isClicked(self):
         """

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -543,8 +543,8 @@ class DwnldWeatherWidget(QWidget):
         elif button == self.btn_goNext:
             self.mergeHistoryIndx += 1
 
-        # self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
-        self.mergeDisplay.setText("Segmentation Fault my ass")
+#        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
+#        self.mergeDisplay.setText("Segmentation Fault my ass")
         if len(self.mergeHistoryLog) > 1:
             if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
                 self.btn_goLast.setEnabled(False)

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -543,23 +543,24 @@ class DwnldWeatherWidget(QWidget):
         elif button == self.btn_goNext:
             self.mergeHistoryIndx += 1
 
-        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
-        if len(self.mergeHistoryLog) > 1:
-            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
-                self.btn_goLast.setEnabled(False)
-                self.btn_goNext.setEnabled(False)
-                self.btn_goFirst.setEnabled(True)
-                self.btn_goPrevious.setEnabled(True)
-            elif self.mergeHistoryIndx == 0:
-                self.btn_goLast.setEnabled(True)
-                self.btn_goNext.setEnabled(True)
-                self.btn_goFirst.setEnabled(False)
-                self.btn_goPrevious.setEnabled(False)
-            else:
-                self.btn_goLast.setEnabled(True)
-                self.btn_goNext.setEnabled(True)
-                self.btn_goFirst.setEnabled(True)
-                self.btn_goPrevious.setEnabled(True)
+        self.mergeDisplay.setText("test")
+#        self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
+#        if len(self.mergeHistoryLog) > 1:
+#            if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
+#                self.btn_goLast.setEnabled(False)
+#                self.btn_goNext.setEnabled(False)
+#                self.btn_goFirst.setEnabled(True)
+#                self.btn_goPrevious.setEnabled(True)
+#            elif self.mergeHistoryIndx == 0:
+#                self.btn_goLast.setEnabled(True)
+#                self.btn_goNext.setEnabled(True)
+#                self.btn_goFirst.setEnabled(False)
+#                self.btn_goPrevious.setEnabled(False)
+#            else:
+#                self.btn_goLast.setEnabled(True)
+#                self.btn_goNext.setEnabled(True)
+#                self.btn_goFirst.setEnabled(True)
+#                self.btn_goPrevious.setEnabled(True)
 
     def btn_selectRaw_isClicked(self):
         """

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -544,7 +544,7 @@ class DwnldWeatherWidget(QWidget):
             self.mergeHistoryIndx += 1
 
         # self.mergeDisplay.setText(self.mergeHistoryLog[self.mergeHistoryIndx])
-        self.mergeDisplay.setText("Segmentation Fault my ass)
+        self.mergeDisplay.setText("Segmentation Fault my ass")
         if len(self.mergeHistoryLog) > 1:
             if self.mergeHistoryIndx == (len(self.mergeHistoryLog) - 1):
                 self.btn_goLast.setEnabled(False)

--- a/WHAT/meteo/dwnld_weather_data.py
+++ b/WHAT/meteo/dwnld_weather_data.py
@@ -196,24 +196,26 @@ class DwnldWeatherWidget(QWidget):
         self.mergeDisplay.setReadOnly(True)
         self.mergeDisplay.setMinimumHeight(250)
 
-        btn_selectRaw = QPushButton('Select')
-        btn_selectRaw.setIcon(IconDB().openFile)
-        btn_selectRaw.setToolTip('Select and format raw weather data files')
-        btn_selectRaw.setIconSize(IconDB().iconSize2)
-        self.btn_selectRaw = btn_selectRaw
+        self.btn_selectRaw = QPushButton('Select')
+        self.btn_selectRaw.setIcon(IconDB().openFile)
+        self.btn_selectRaw.setToolTip(
+                "Select and concatenate raw weather data files.")
+        self.btn_selectRaw.setIconSize(IconDB().iconSize2)
+        self.btn_selectRaw.clicked.connect(self.btn_selectRaw_isClicked)
 
-        btn_saveMerge = QPushButton('Save')
-        btn_saveMerge.setToolTip('Save formated weather data in a csv file')
-        btn_saveMerge.setIcon(IconDB().save)
-        btn_saveMerge.setIconSize(IconDB().iconSize2)
+        self.btn_saveMerge = QPushButton('Save')
+        self.btn_saveMerge.setToolTip(
+                "Save the concatenated weather dataset in a csv file.")
+        self.btn_saveMerge.setIcon(IconDB().save)
+        self.btn_saveMerge.setIconSize(IconDB().iconSize2)
+        self.btn_saveMerge.clicked.connect(self.btn_saveMerge_isClicked)
 
         rightPanel_grid = QGridLayout()
         rightPanel_widg = QFrame()
 
         row = 0
-
-        rightPanel_grid.addWidget(btn_selectRaw, row, 0)
-        rightPanel_grid.addWidget(btn_saveMerge, row, 1)
+        rightPanel_grid.addWidget(self.btn_selectRaw, row, 0)
+        rightPanel_grid.addWidget(self.btn_saveMerge, row, 1)
         row += 1
         rightPanel_grid.addWidget(self.mergeDisplay, row, 0, 1, 3)
         row += 1
@@ -229,7 +231,7 @@ class DwnldWeatherWidget(QWidget):
 
         rightPanel_widg.setLayout(rightPanel_grid)
 
-        # ------------------------------------------------------ Main Grid ----
+        # ---- Main Grid
 
         main_grid = QGridLayout()
 
@@ -248,26 +250,22 @@ class DwnldWeatherWidget(QWidget):
 
         self.setLayout(main_grid)
 
-        # --------------------------------------------------------- EVENTS ----
+        # ---- Events
 
-        # ---- concatenate raw data ----
-
-        btn_selectRaw.clicked.connect(self.btn_selectRaw_isClicked)
+        # concatenate raw data
 
         self.btn_goLast.clicked.connect(self.display_mergeHistory)
         self.btn_goFirst.clicked.connect(self.display_mergeHistory)
         self.btn_goNext.clicked.connect(self.display_mergeHistory)
         self.btn_goPrevious.clicked.connect(self.display_mergeHistory)
 
-        btn_saveMerge.clicked.connect(self.btn_saveMerge_isClicked)
-
-        # ---- weather station list ----
+        # weather station list
 
         btn_delSta.clicked.connect(self.btn_delSta_isClicked)
         btn_browse_staList.clicked.connect(self.btn_browse_staList_isClicked)
         self.btn_save_staList.clicked.connect(self.btn_save_staList_isClicked)
 
-        # ---- search4stations ----
+        # search4stations
 
         btn_search4station.clicked.connect(self.search4stations.show)
         self.search4stations.staListSignal.connect(self.add_stations2list)

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -262,6 +262,10 @@ def test_merge_widget(downloader_bot, mocker):
     wxdata_downloader, qtbot = downloader_bot
     wxdata_downloader.show()
 
+    qtbot.waitActive(wxdata_downloader, timeout=3000)
+    qtbot.waitForWindowShown(wxdata_downloader)
+    qtbot.wait(3000)
+
     projetpath = os.path.join(os.getcwd(), "@ new-prô'jèt!")
     wxdata_downloader.set_workdir(projetpath)
 

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -263,7 +263,6 @@ def test_merge_widget(downloader_bot, mocker):
     wxdata_downloader.show()
 
     qtbot.waitActive(wxdata_downloader, timeout=3000)
-    qtbot.waitForWindowShown(wxdata_downloader)
     qtbot.wait(3000)
 
     projetpath = os.path.join(os.getcwd(), "@ new-prô'jèt!")
@@ -290,6 +289,8 @@ def test_merge_widget(downloader_bot, mocker):
         mocker.patch.object(QFileDialog, 'getOpenFileNames',
                             return_value=(paths, '*.csv'))
         wxdata_downloader.btn_selectRaw_isClicked()
+
+        qtbot.waitActive(wxdata_downloader, timeout=3000)
 
     # Assert that the concatenated files were not saved.
     dirname = os.path.join(os.getcwd(), "@ new-prô'jèt!", "Meteo", "Input")

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -288,9 +288,7 @@ def test_merge_widget(downloader_bot, mocker):
 
         mocker.patch.object(QFileDialog, 'getOpenFileNames',
                             return_value=(paths, '*.csv'))
-        wxdata_downloader.btn_selectRaw_isClicked()
-
-        qtbot.waitActive(wxdata_downloader, timeout=3000)
+        qtbot.mouseClick(wxdata_downloader.btn_selectRaw, Qt.LeftButton)
 
     # Assert that the concatenated files were not saved.
     dirname = os.path.join(os.getcwd(), "@ new-prô'jèt!", "Meteo", "Input")

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -308,6 +308,7 @@ def test_merge_widget(downloader_bot, mocker):
     qtbot.waitUntil(lambda: wxdata_downloader.btn_goNext.isEnabled())
 
     # Save the file and assert that it was created as expected
+    mocker.patch.object(QFileDialog, 'getSaveFileName',
                         return_value=(filepaths[0], '*.csv'))
     qtbot.mouseClick(wxdata_downloader.btn_saveMerge, Qt.LeftButton)
     qtbot.waitUntil(lambda: os.path.exists(filepaths[0]))
@@ -321,6 +322,7 @@ def test_merge_widget(downloader_bot, mocker):
     qtbot.waitUntil(lambda: not wxdata_downloader.btn_goNext.isEnabled())
 
     # Save the file and assert that it was created as expected
+    mocker.patch.object(QFileDialog, 'getSaveFileName',
                         return_value=(filepaths[-1], '*.csv'))
     qtbot.mouseClick(wxdata_downloader.btn_saveMerge, Qt.LeftButton)
     qtbot.waitUntil(lambda: os.path.exists(filepaths[-1]))
@@ -334,6 +336,7 @@ def test_merge_widget(downloader_bot, mocker):
     qtbot.waitUntil(lambda: wxdata_downloader.btn_goNext.isEnabled())
 
     # Save the file and assert that it was created as expected
+    mocker.patch.object(QFileDialog, 'getSaveFileName',
                         return_value=(filepaths[-2], '*.csv'))
     qtbot.mouseClick(wxdata_downloader.btn_saveMerge, Qt.LeftButton)
     qtbot.waitUntil(lambda: os.path.exists(filepaths[-2]))

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -262,9 +262,7 @@ def test_merge_widget(downloader_bot, mocker):
     wxdata_downloader, qtbot = downloader_bot
     wxdata_downloader.show()
 
-    qtbot.waitActive(wxdata_downloader, timeout=3000)
     qtbot.waitForWindowShown(wxdata_downloader)
-    qtbot.wait(3000)
 
     projetpath = os.path.join(os.getcwd(), "@ new-prô'jèt!")
     wxdata_downloader.set_workdir(projetpath)

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -263,7 +263,6 @@ def test_merge_widget(downloader_bot, mocker):
     wxdata_downloader.show()
 
     qtbot.waitActive(wxdata_downloader, timeout=3000)
-    qtbot.wait(3000)
 
     projetpath = os.path.join(os.getcwd(), "@ new-prô'jèt!")
     wxdata_downloader.set_workdir(projetpath)

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -285,7 +285,10 @@ def test_merge_widget(downloader_bot, mocker):
 
         mocker.patch.object(QFileDialog, 'getOpenFileNames',
                             return_value=(paths, '*.csv'))
-        wxdata_downloader.btn_selectRaw_isClicked()
+
+        sig = wxdata_downloader.sig_merge_summary_displayed
+        with qtbot.waitSignal(sig, raising=True, timeout=60000):
+            wxdata_downloader.btn_selectRaw_isClicked()
 
     # Assert that the concatenated files were not saved.
     dirname = os.path.join(os.getcwd(), "@ new-prô'jèt!", "Meteo", "Input")

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -285,10 +285,7 @@ def test_merge_widget(downloader_bot, mocker):
 
         mocker.patch.object(QFileDialog, 'getOpenFileNames',
                             return_value=(paths, '*.csv'))
-
-        sig = wxdata_downloader.sig_merge_summary_displayed
-        with qtbot.waitSignal(sig, raising=True, timeout=60000):
-            wxdata_downloader.btn_selectRaw_isClicked()
+        wxdata_downloader.btn_selectRaw_isClicked()
 
     # Assert that the concatenated files were not saved.
     dirname = os.path.join(os.getcwd(), "@ new-prô'jèt!", "Meteo", "Input")

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -262,7 +262,9 @@ def test_merge_widget(downloader_bot, mocker):
     wxdata_downloader, qtbot = downloader_bot
     wxdata_downloader.show()
 
+    qtbot.waitActive(wxdata_downloader, timeout=3000)
     qtbot.waitForWindowShown(wxdata_downloader)
+    qtbot.wait(3000)
 
     projetpath = os.path.join(os.getcwd(), "@ new-prô'jèt!")
     wxdata_downloader.set_workdir(projetpath)

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -295,14 +295,56 @@ def test_merge_widget(downloader_bot, mocker):
                  "IBERVILLE (7023270)_2000-2002.csv",
                  "L'ACADIE (702LED4)_2000-2002.csv"]
 
-    for file in filenames:
-        assert not os.path.exists(os.path.join(dirname, file))
+    filepaths = [os.path.join(dirname, f) for f in filenames]
+    for path in filepaths:
+        assert not os.path.exists(path)
 
-    # Navigate through with the merge widget.
+    # Navigate to the first concatedated dataset and assert that
+    # the navigation buttons are enabled/disabled as expected.
     qtbot.mouseClick(wxdata_downloader.btn_goFirst, Qt.LeftButton)
+    qtbot.waitUntil(lambda: not wxdata_downloader.btn_goFirst.isEnabled())
+    qtbot.waitUntil(lambda: not wxdata_downloader.btn_goPrevious.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goLast.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goNext.isEnabled())
+
+    # Save the file and assert that it was created as expected
+                        return_value=(filepaths[0], '*.csv'))
+    qtbot.mouseClick(wxdata_downloader.btn_saveMerge, Qt.LeftButton)
+    qtbot.waitUntil(lambda: os.path.exists(filepaths[0]))
+
+    # Navigate to the last concatedated dataset and assert that
+    # the navigation buttons are enabled/disabled as expected.
     qtbot.mouseClick(wxdata_downloader.btn_goLast, Qt.LeftButton)
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goFirst.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goPrevious.isEnabled())
+    qtbot.waitUntil(lambda: not wxdata_downloader.btn_goLast.isEnabled())
+    qtbot.waitUntil(lambda: not wxdata_downloader.btn_goNext.isEnabled())
+
+    # Save the file and assert that it was created as expected
+                        return_value=(filepaths[-1], '*.csv'))
+    qtbot.mouseClick(wxdata_downloader.btn_saveMerge, Qt.LeftButton)
+    qtbot.waitUntil(lambda: os.path.exists(filepaths[-1]))
+
+    # Navigate to the previous concatedated dataset and assert that
+    # the navigation buttons are enabled/disabled as expected.
     qtbot.mouseClick(wxdata_downloader.btn_goPrevious, Qt.LeftButton)
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goFirst.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goPrevious.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goLast.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goNext.isEnabled())
+
+    # Save the file and assert that it was created as expected
+                        return_value=(filepaths[-2], '*.csv'))
+    qtbot.mouseClick(wxdata_downloader.btn_saveMerge, Qt.LeftButton)
+    qtbot.waitUntil(lambda: os.path.exists(filepaths[-2]))
+
+    # Navigate to the next concatedated dataset and assert that
+    # the navigation buttons are enabled/disabled as expected.
     qtbot.mouseClick(wxdata_downloader.btn_goNext, Qt.LeftButton)
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goFirst.isEnabled())
+    qtbot.waitUntil(lambda: wxdata_downloader.btn_goPrevious.isEnabled())
+    qtbot.waitUntil(lambda: not wxdata_downloader.btn_goLast.isEnabled())
+    qtbot.waitUntil(lambda: not wxdata_downloader.btn_goNext.isEnabled())
 
 
 if __name__ == "__main__":                                   # pragma: no cover


### PR DESCRIPTION
The reason for the test to result in a segmentation fault error on Travis and not on AppVeyor is not clear.

What I did to solve the problem is, instead of bypassing qtbot and calling directly the methods `btn_selectRaw_isClicked` and `btn_selectRaw_isClicked` in the test, I now use the qtbot to actually simulate a click on `btn_selectRaw` and `btn_selectRaw`. This appears to have solve all segmentation fault problems on Travis.