### PR TITLE
PR: Link AppVeyor with Coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,7 +9,14 @@ omit =
     */Reference/*
     */Releases/*
     */User_Manual/*
-    */tests/*
 
 [report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run
+    if __name__ == .__main__.:
+
 fail_under=0

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,14 +1,14 @@
 [run]
 omit = 
     */Backup/*
-    */Benchmark/*
     */Images/*  
     */Projects/*
     */PyInstaller 3.2.1-dev/*
     */PyInstaller-3.2.1/*
     */Reference/*
     */Releases/*
-    */User_Manual/*
+    */User_Manual/
+    */tests/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
     */Reference/*
     */Releases/*
     */User_Manual/*
+    */tests/*
 
 [report]
 fail_under=0

--- a/WHAT/tests/__init__.py
+++ b/WHAT/tests/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) Spyder Project Contributors
+#
+# Licensed under the terms of the MIT License
+# (see LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+
+"""Tests."""

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 environment:
   COVERALLS_REPO_TOKEN:
-    - secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
+    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
   matrix:
     - PYTHON_VERSION: "3.6"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 environment:
   COVERALLS_REPO_TOKEN:
-    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
+    - secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
   matrix:
     - PYTHON_VERSION: "3.6"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 environment:
   COVERALLS_REPO_TOKEN:
-  secure: 6tdds8x61Nm9X9NRdsdsd+hlU0iEyo8g+457eAJTisdhK14SERTfdfS7vsdOp1et+h
+    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
 
   global:
     PYTHON: "C:\\conda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ build: false
 test_script:
   - "%CMD_IN_ENV% python runtests.py"
 
-after_success:
+on_success:
   - "%CMD_IN_ENV% coveralls"
 
 on_finish:  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,21 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
+  COVERALLS_SERVICE_NAME: appveyor
   COVERALLS_REPO_TOKEN:
-    - secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
+    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
+
+  global:
+    PYTHON: "C:\\conda"
+    MINICONDA_VERSION: "latest"
+    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
+    PYTHON_ARCH: "64"
+    PIP_DEPENDENCIES_FLAGS: "-q"
+    CONDA_DEPENDENCIES_FLAGS: "--quiet"
+    CONDA_DEPENDENCIES: >
+      mock pytest pytest-cov scipy matplotlib
+    PIP_DEPENDENCIES: "pytest-qt pytest-mock pytest-timeout pytest-ordering"
+
   matrix:
     - PYTHON_VERSION: "3.6"
 
@@ -25,19 +38,14 @@ install:
       https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
       Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
+  - "git clone git://github.com/astropy/ci-helpers.git"
+  - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - pip install pyqt5
-  - pip install h5py
-  - pip install xlsxwriter
+  - "activate test"
   - pip install xlrd
-  - pip install pytest
-  - pip install pytest-qt
-  - pip install pytest-xvfb
-  - pip install pytest-mock
-  - pip install pytest-cov
-  - pip install pytest-ordering
+  - pip install xlsxwriter
+  - pip install h5py
   - pip install coveralls
-  - pip install matplotlib
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,10 @@
-# https://ci.appveyor.com/project/jnsebgosselin/WHAT
+# https://ci.appveyor.com/project/jnsebgosselin/what
 
 # scripts that are called at very beginning, before repo cloning
 init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
-  COVERALLS_SERVICE_NAME: appveyor
   COVERALLS_REPO_TOKEN:
     secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
+  my_variable:
+    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
 
   global:
     PYTHON: "C:\\conda"
@@ -49,5 +51,8 @@ build: false
 test_script:
   - "%CMD_IN_ENV% python runtests.py"
 
-on_finish:
+after_success:
+  - "%CMD_IN_ENV% coveralls"
+
+on_finish:  
 #   - ps: $blockRdp = $false; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
+  COVERALLS_SERVICE_NAME: appveyor
   COVERALLS_REPO_TOKEN:
     secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
-  my_variable:
-    COVERALLS_REPO_TOKEN: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
+  COVERALLS_REPO_TOKEN:
+  secure: 6tdds8x61Nm9X9NRdsdsd+hlU0iEyo8g+457eAJTisdhK14SERTfdfS7vsdOp1et+h
 
   global:
     PYTHON: "C:\\conda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ init:
 
 environment:
   my_variable:
-    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
+    COVERALLS_REPO_TOKEN: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
 
   global:
     PYTHON: "C:\\conda"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,21 +5,8 @@ init:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 environment:
-  COVERALLS_SERVICE_NAME: appveyor
   COVERALLS_REPO_TOKEN:
-    secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
-
-  global:
-    PYTHON: "C:\\conda"
-    MINICONDA_VERSION: "latest"
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    PYTHON_ARCH: "64"
-    PIP_DEPENDENCIES_FLAGS: "-q"
-    CONDA_DEPENDENCIES_FLAGS: "--quiet"
-    CONDA_DEPENDENCIES: >
-      mock pytest pytest-cov scipy matplotlib
-    PIP_DEPENDENCIES: "pytest-qt pytest-mock pytest-timeout pytest-ordering"
-
+    - secure: C6f+X1lfx0nlwaBgRIbl3vEwy+EOkw7OAlkQquh76IK7Oz9JRhcwqj7/lSeumDIL
   matrix:
     - PYTHON_VERSION: "3.6"
 
@@ -38,14 +25,19 @@ install:
       https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
       Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
-  - "git clone git://github.com/astropy/ci-helpers.git"
-  - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "activate test"
-  - pip install xlrd
-  - pip install xlsxwriter
+  - pip install pyqt5
   - pip install h5py
+  - pip install xlsxwriter
+  - pip install xlrd
+  - pip install pytest
+  - pip install pytest-qt
+  - pip install pytest-xvfb
+  - pip install pytest-mock
+  - pip install pytest-cov
+  - pip install pytest-ordering
   - pip install coveralls
+  - pip install matplotlib
 
 build: false
 

--- a/runtests.py
+++ b/runtests.py
@@ -15,7 +15,7 @@ def main():
     """
     Run pytest tests.
     """
-    pytest.main(['-x', 'WHAT',  '-v', '-rw', '--durations=10', '--cov'])
+    pytest.main(['-x', 'WHAT',  '-v', '-rw', '--durations=10', '--cov=WHAT'])
 
 
 if __name__ == '__main__':

--- a/runtests.py
+++ b/runtests.py
@@ -9,14 +9,13 @@ File for running tests programmatically.
 """
 
 import pytest
-import WHAT
 
 
 def main():
     """
     Run pytest tests.
     """
-    pytest.main(['-x', 'WHAT',  '-v', '-rw', '--durations=10', '--cov=WHAT'])
+    pytest.main(['-x', 'WHAT',  '-v', '-rw', '--durations=10', '--cov'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Currently, only Travis send info to Coveralls. The goal here is to also make AppVeyor send the info.