### PR TITLE
PR: Add a method to format the content of a WeatherSationList into a HTML table

### DIFF
--- a/WHAT/meteo/weather_stationlist.py
+++ b/WHAT/meteo/weather_stationlist.py
@@ -102,6 +102,17 @@ class WeatherSationList(list):
 
             print('Station list saved successfully in %s' % filename)
 
+    def format_list_in_html(self):
+        html = "<table>"
+        for station in self:
+            html += "<tr>"
+            for attrs in station:
+                html = '<td>%s</td>' % attrs
+            html += "</tr>"
+        html += "</table>"
+
+        return html
+
 
 if __name__ == '__main__':
     fname = ("C:\\Users\\jsgosselin\\OneDrive\\WHAT\\WHAT\\tests\\"

--- a/WHAT/meteo/weather_stationlist.py
+++ b/WHAT/meteo/weather_stationlist.py
@@ -107,7 +107,7 @@ class WeatherSationList(list):
         for station in self:
             html += "<tr>"
             for attrs in station:
-                html = '<td>%s</td>' % attrs
+                html += '<td>%s</td>' % attrs
             html += "</tr>"
         html += "</table>"
 

--- a/WHAT/meteo/weather_stationlist.py
+++ b/WHAT/meteo/weather_stationlist.py
@@ -103,6 +103,7 @@ class WeatherSationList(list):
             print('Station list saved successfully in %s' % filename)
 
     def format_list_in_html(self):
+        """Format the content of the weather station list into a HTML table."""
         html = "<table>"
         html += "<tr>"
         for attrs in self.HEADER:

--- a/WHAT/meteo/weather_stationlist.py
+++ b/WHAT/meteo/weather_stationlist.py
@@ -104,6 +104,10 @@ class WeatherSationList(list):
 
     def format_list_in_html(self):
         html = "<table>"
+        html += "<tr>"
+        for attrs in self.HEADER:
+            html += '<th>%s</th>' % attrs
+        html += "<tr>"
         for station in self:
             html += "<tr>"
             for attrs in station:

--- a/WHAT/tests/test_dwnld_weather_data.py
+++ b/WHAT/tests/test_dwnld_weather_data.py
@@ -132,7 +132,11 @@ def test_load_stationlist(downloader_bot, mocker):
     wxdata_downloader.btn_browse_staList_isClicked()
 
     # Assert that the data are stored correctly in the widget table.
-    assert expected_result == wxdata_downloader.station_table.get_stationlist()
+    station_list = wxdata_downloader.station_table.get_stationlist()
+    assert expected_result == station_list
+
+    # Test that the station list formating to html works without any error.
+    station_list.format_list_in_html()
 
     # Try to open a station list when the file does not exist.
     wxdata_downloader.load_stationList("dummy.lst")


### PR DESCRIPTION
This would be useful for instance when printing a WeatherSationList in a notebook.

- [x] add the feature
- [x] include it in a test

![image](https://user-images.githubusercontent.com/10170372/31178268-84efcc0a-a8e6-11e7-9536-a2a0010ab19c.png)
