### PR TITLE
PR: Fix import error due to module not found in WHAT

### DIFF
--- a/WHAT/HydroCalc2.py
+++ b/WHAT/HydroCalc2.py
@@ -49,13 +49,13 @@ import xlsxwriter
 
 # Local imports :
 
-from gwrecharge_calc2 import SynthHydrograph
-from gwrecharge_post import plot_rechg_GLUE
+from WHAT.gwrecharge_calc2 import SynthHydrograph
+from WHAT.gwrecharge_post import plot_rechg_GLUE
 
-import common.database as db
-import common.widgets as myqt
-from common import IconDB, StyleDB, QToolButtonNormal
-import brf_mod as bm
+import WHAT.common.database as db
+import WHAT.common.widgets as myqt
+from WHAT.common import IconDB, StyleDB, QToolButtonNormal
+import WHAT.brf_mod as bm
 
 mpl.use('Qt5Agg')
 mpl.rc('font', **{'family': 'sans-serif', 'sans-serif': ['Arial']})

--- a/WHAT/HydroPrint2.py
+++ b/WHAT/HydroPrint2.py
@@ -21,14 +21,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 from __future__ import division, unicode_literals
 
-# Standard library imports :
+# ---- Standard library imports
 
 import csv
 import sys
 import os
 import copy
 
-# Third party imports :
+# ---- Third party imports
 
 from PyQt5.QtCore import Qt, QDate, QCoreApplication, QPoint
 from PyQt5.QtCore import pyqtSignal as QSignal
@@ -42,17 +42,17 @@ import numpy as np
 from xlrd.xldate import xldate_from_date_tuple
 from xlrd import xldate_as_tuple
 
-# Local imports :
+# ---- Local imports
 
-import hydrograph4 as hydrograph
-import mplFigViewer3 as mplFigViewer
-from meteo.weather_viewer import WeatherAvgGraph
-from colors2 import ColorsReader, ColorsSetupWin
+import WHAT.hydrograph4 as hydrograph
+import WHAT.mplFigViewer3 as mplFigViewer
+from WHAT.meteo.weather_viewer import WeatherAvgGraph
+from WHAT.colors2 import ColorsReader, ColorsSetupWin
 
-from common import IconDB, StyleDB, QToolButtonNormal, QToolButtonSmall
-import common.widgets as myqt
-import common.database as db
-from projet.reader_waterlvl import load_waterlvl_measures
+from WHAT.common import IconDB, StyleDB, QToolButtonNormal, QToolButtonSmall
+import WHAT.common.widgets as myqt
+import WHAT.common.database as db
+from WHAT.projet.reader_waterlvl import load_waterlvl_measures
 
 
 # =============================================================================

--- a/WHAT/__init__.py
+++ b/WHAT/__init__.py
@@ -4,6 +4,6 @@ Created on Sat Apr  8 13:56:17 2017
 @author: jnsebgosselin
 """
 
-__version__ = 'WHAT 4.2.0-Beta2'
-__date__ = '06/26/2017'
+__version__ = 'WHAT 4.2.0'
+__date__ = '06/11/2017'
 __project_url__ = 'https://github.com/jnsebgosselin/what'

--- a/WHAT/brf_mod/__init__.py
+++ b/WHAT/brf_mod/__init__.py
@@ -3,9 +3,9 @@
 >>> import brf_mod as bm
 """
 
-from brf_mod.kgs_brf import (produce_BRFInputtxt, produce_par_file, run_kgsbrf,
-                             read_BRFOutput)
+from WHAT.brf_mod.kgs_brf import (produce_BRFInputtxt, produce_par_file,
+                                  run_kgsbrf, read_BRFOutput)
 
-from brf_mod.kgs_gui import BRFManager
+from WHAT.brf_mod.kgs_gui import BRFManager
 
 __version__ = '1.2.0'

--- a/WHAT/brf_mod/kgs_brf.py
+++ b/WHAT/brf_mod/kgs_brf.py
@@ -19,28 +19,20 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 """
 
-# Standard library imports :
+# ---- Standard library imports
 
 import os
 import csv
 
-# Third party imports :
+# ---- Third party imports
 
 import numpy as np
 import matplotlib.pyplot as plt
 from xlrd import xldate_as_tuple
 
-# Local imports :
+# ---- Local imports
 
-if __name__ == '__main__':
-    print('Running module as a standalone script...')
-    import sys
-    import platform
-    from os.path import dirname, realpath
-    root = dirname(dirname(realpath(__file__)))
-    sys.path.append(root)
-
-from brf_mod.kgs_plot import plot_BRF
+from WHAT.brf_mod.kgs_plot import plot_BRF
 
 
 # =============================================================================

--- a/WHAT/brf_mod/kgs_gui.py
+++ b/WHAT/brf_mod/kgs_gui.py
@@ -31,10 +31,10 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
 
-import common.widgets as myqt
-from brf_mod.kgs_plot import BRFFigure
-from common import IconDB, StyleDB, QToolButtonNormal, QToolButtonSmall
-import brf_mod as bm
+import WHAT.common.widgets as myqt
+from WHAT.brf_mod.kgs_plot import BRFFigure
+from WHAT.common import IconDB, StyleDB, QToolButtonNormal, QToolButtonSmall
+from WHAT import brf_mod as bm
 
 mpl.use('Qt5Agg')
 mpl.rc('font', **{'family': 'sans-serif', 'sans-serif': ['Arial']})

--- a/WHAT/brf_mod/kgs_plot.py
+++ b/WHAT/brf_mod/kgs_plot.py
@@ -24,7 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 from os import getcwd
 
-# Third party imports:
+# ---- Third party imports
+
 from matplotlib import pyplot as plt
 import matplotlib as mpl
 import numpy as np

--- a/WHAT/custom_widgets.py
+++ b/WHAT/custom_widgets.py
@@ -12,8 +12,8 @@ import sys
 from PySide import QtGui, QtCore
 
 # PERSONAL IMPORTS :
-import common.database as db
-from common import IconDB, StyleDB, QToolButtonNormal
+import WHAT.common.database as db
+from WHAT.common import IconDB, StyleDB, QToolButtonNormal
 
 ###############################################################################
 

--- a/WHAT/gwrecharge_calc2.py
+++ b/WHAT/gwrecharge_calc2.py
@@ -21,24 +21,24 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division, unicode_literals
 
-# Standard library imports :
+# ---- Standard library imports
 
 # from datetime import date
 import csv
 import datetime
 
-# Third party imports :
+# ---- Third party imports
 
 import numpy as np
 # from xlrd import xldate_as_tuple
 from xlrd.xldate import xldate_from_date_tuple
 import matplotlib.pyplot as plt
 
-# Local imports :
+# ---- Local imports
 
-import meteo.weather_reader as wxrd
-from waterlvldata import WaterlvlData
-from gwrecharge_post import plot_water_budget_yearly
+import WHAT.meteo.weather_reader as wxrd
+from WHAT.waterlvldata import WaterlvlData
+from WHAT.gwrecharge_post import plot_water_budget_yearly
 
 
 # =============================================================================

--- a/WHAT/gwrecharge_post.py
+++ b/WHAT/gwrecharge_post.py
@@ -21,13 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division, unicode_literals
 
-# ----- STANDARD LIBRARY IMPORTS -----
+# ---- Standard library imports
 
 # from datetime import date
 import csv
 import datetime
 
-# ----- THIRD PARTY IMPORTS -----
+# ---- Third party imports
 
 import numpy as np
 import matplotlib as mpl
@@ -35,10 +35,10 @@ from xlrd import xldate_as_tuple
 # from xlrd.xldate import xldate_from_date_tuple
 import matplotlib.pyplot as plt
 
-# ----- PERSONAL LIBRARY IMPORTS -----
+# Local imports
 
-from waterlvldata import WaterlvlData
-import mplJS
+from WHAT.waterlvldata import WaterlvlData
+import WHAT.mplJS
 
 
 # =============================================================================

--- a/WHAT/projet/manager_data.py
+++ b/WHAT/projet/manager_data.py
@@ -21,12 +21,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 from __future__ import division, unicode_literals
 
-# Standard library imports :
+# ---- Standard library imports
 
 import os
 from datetime import datetime
 
-# Third party imports :
+# ---- Third party imports
 
 from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtCore import pyqtSignal as QSignal
@@ -34,13 +34,13 @@ from PyQt5.QtWidgets import (QWidget, QComboBox, QGridLayout, QTextEdit,
                              QLabel, QMessageBox, QLineEdit, QPushButton,
                              QFileDialog, QApplication)
 
-# Local imports :
+# ---- Local imports
 
-from common import IconDB, QToolButtonSmall
-import common.widgets as myqt
-from hydrograph4 import LatLong2Dist
-import projet.reader_waterlvl as wlrd
-import meteo.weather_reader as wxrd
+from WHAT.common import IconDB, QToolButtonSmall
+import WHAT.common.widgets as myqt
+from WHAT.hydrograph4 import LatLong2Dist
+import WHAT.projet.reader_waterlvl as wlrd
+import WHAT.meteo.weather_reader as wxrd
 
 # :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/WHAT/projet/manager_projet.py
+++ b/WHAT/projet/manager_projet.py
@@ -21,12 +21,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 from __future__ import division, unicode_literals
 
-# Standard library imports :
+# ---- Standard library imports
 
 import os
 from datetime import datetime
 
-# Third party imports :
+# ---- Third party imports
 
 from PyQt5.QtCore import pyqtSignal as QSignal
 from PyQt5.QtCore import Qt, QPoint
@@ -34,12 +34,12 @@ from PyQt5.QtWidgets import (QWidget, QLabel, QDesktopWidget, QPushButton,
                              QApplication, QGridLayout, QMessageBox, QDialog,
                              QLineEdit, QToolButton, QFileDialog)
 
-# Local imports :
+# ---- Local imports
 
-from projet.reader_projet import ProjetReader
-from common import IconDB, QToolButtonSmall
-from projet.manager_data import DataManager
-import common.widgets as myqt
+from WHAT.projet.reader_projet import ProjetReader
+from WHAT.common import IconDB, QToolButtonSmall
+from WHAT.projet.manager_data import DataManager
+import WHAT.common.widgets as myqt
 from WHAT import __version__
 
 

--- a/WHAT/projet/reader_projet.py
+++ b/WHAT/projet/reader_projet.py
@@ -363,6 +363,16 @@ class WLDataFrameHDF5(dict):
         print(peak_indx)
 
     def mrc_exists(self):
+        if 'mrc' not in list(self.dset.keys()):
+            mrc = self.dset.create_group('mrc')
+            mrc.attrs['exists'] = 0
+            mrc.create_dataset('params', data=(0, 0), dtype='float64')
+            mrc.create_dataset('peak_indx', data=np.array([]),
+                               dtype='int16', maxshape=(None,))
+            mrc.create_dataset('recess', data=np.array([]),
+                               dtype='float64', maxshape=(None,))
+            mrc.create_dataset('time', data=np.array([]),
+                               dtype='float64', maxshape=(None,))
         return bool(self.dset['mrc'].attrs['exists'])
 
     # ================================================================ BRF ====

--- a/WHAT/tests/test_merge_weather_data.py
+++ b/WHAT/tests/test_merge_weather_data.py
@@ -16,10 +16,10 @@ from PyQt5.QtCore import Qt
 
 # Local imports
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
-from meteo.dwnld_weather_data import ConcatenatedDataFrame
-from meteo.weather_reader import read_weather_datafile
-from meteo.merge_weather_data import (WXDataMerger, WXDataMergerWidget,
-                                      QFileDialog)
+from WHAT.meteo.dwnld_weather_data import ConcatenatedDataFrame
+from WHAT.meteo.weather_reader import read_weather_datafile
+from WHAT.meteo.merge_weather_data import (WXDataMerger, WXDataMergerWidget,
+                                           QFileDialog)
 
 
 # Qt Test Fixtures

--- a/WHAT/tests/test_projet.py
+++ b/WHAT/tests/test_projet.py
@@ -11,8 +11,8 @@ import os.path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 # Local imports
-from projet.reader_projet import ProjetReader                          # nopep8
-from projet.manager_projet import (ProjetManager, QFileDialog)         # nopep8
+from WHAT.projet.reader_projet import ProjetReader                     # nopep8
+from WHAT.projet.manager_projet import (ProjetManager, QFileDialog)    # nopep8
 
 
 # Qt Test Fixtures

--- a/WHAT/tests/test_search_weather_data.py
+++ b/WHAT/tests/test_search_weather_data.py
@@ -11,8 +11,8 @@ import os
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 
 # Local imports
-from meteo.search_weather_data import Search4Stations                  # nopep8
-from meteo.search_weather_data import QFileDialog                      # nopep8
+from WHAT.meteo.search_weather_data import Search4Stations             # nopep8
+from WHAT.meteo.search_weather_data import QFileDialog                 # nopep8
 
 
 # ---- Qt Test Fixtures

--- a/WHAT/widgets/about.py
+++ b/WHAT/widgets/about.py
@@ -32,7 +32,7 @@ from PyQt5.QtWidgets import (QDialog, QTextBrowser, QPushButton, QGridLayout,
 # Local imports :
 
 from WHAT import __version__, __date__
-from common import IconDB
+from WHAT.common import IconDB
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #77

The objective is to fix all import errors that were introduced when WHAT was made a module. We also prevent in this patch WHAT to crash when trying to load an older WHAT project file.